### PR TITLE
Fixed random study

### DIFF
--- a/Python/fixed_random.ipynb
+++ b/Python/fixed_random.ipynb
@@ -1723,7 +1723,7 @@
    "id": "34ba800f",
    "metadata": {},
    "source": [
-    "Observed that the uncertainty of $b_{zy}$ is higher in the fixed effects model. The reason is because the intercepts and the group-level $z$ terms are not identifiable (there are many ways to sum up two numbers to get the same group-level intercept)."
+    "Observe that the uncertainty of $b_{zy}$ is higher in the fixed effects model. The reason is because the intercepts and the group-level $z$ terms are not identifiable (there are many ways to sum up two numbers to get the same group-level intercept)."
    ]
   },
   {
@@ -2245,7 +2245,7 @@
    "id": "fc6df030",
    "metadata": {},
    "source": [
-    "In this case, the multilevel model is not able to estimate the true value of $b_{xy}$. The reason is that is not really factoring out the group-level confounding through the mean. Still, for the model $b_{zy}$ we do get the correct estimate with narrower uncertainty as compared to the fixed effects model:"
+    "In this case, the multilevel model is not able to estimate the true value of $b_{xy}$. The reason is that it is not really factoring out the group-level confounding through the mean. Still, for this model, $b_{zy}$ is correctly estimated with narrower uncertainty as compared to the fixed effects model:"
    ]
   },
   {
@@ -2836,7 +2836,7 @@
    "id": "80516891",
    "metadata": {},
    "source": [
-    "This model is able to estimate the true value of $b_{xy}$ and $b_{zy}$ with finer uncertainty for $b_{zy}$ as compared to the fixed effects model."
+    "This model is able to estimate the true value of $b_{xy}$ and $b_{zy}$ with narrower uncertainty for $b_{zy}$ as compared to the fixed effects model."
    ]
   },
   {


### PR DESCRIPTION
reproduce models from https://www.youtube.com/watch?v=XNNcN8sU8us

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this appears to be a self-contained notebook addition/adjustment with no impact on production code paths.
> 
> **Overview**
> Adds/updates the `Python/fixed_random.ipynb` notebook to reproduce the *fixed vs random effects* simulated study from Richard McElreath’s Statistical Rethinking lecture, including data generation and PyMC model specification/sampling workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f3b893f4a6978f9d90547d33e39527b024cfef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->